### PR TITLE
fix(sc-7415): Allow empty callback URLs to be saved

### DIFF
--- a/Form/Type/Admin/Smartpay/CallbackURLs.php
+++ b/Form/Type/Admin/Smartpay/CallbackURLs.php
@@ -25,14 +25,12 @@ class CallbackURLs extends AbstractType
     {
         $builder
             ->add('success_url', TextType::class, [
-                'constraints' => [
-                    new NotBlank()
-                ]
+                'required' => false,
+                'constraints' => []
             ])
             ->add('cancel_url', TextType::class, [
-                'constraints' => [
-                    new NotBlank()
-                ]
-                ]);
+                'required' => false,
+                'constraints' => []
+            ]);
     }
 }

--- a/Resource/template/admin/Smartpay/callback_urls.twig
+++ b/Resource/template/admin/Smartpay/callback_urls.twig
@@ -23,16 +23,14 @@
                         <div class="card-header"><span>{{ 'smartpay.admin.config.header'|trans }}</span></div>
                         <div class="card-body">
                             <div class="row">
-                                <div class="col-3"><span>{{ 'サクセスURL'|trans }}</span><span
-                                        class="badge badge-primary ml-1">{{ 'smartpay.admin.config.required'|trans }}</span></div>
+                                <div class="col-3"><span>{{ 'サクセスURL'|trans }}</span></div>
                                 <div class="col mb-2">
                                     {{ form_widget(form.success_url) }}
                                     {{ form_errors(form.success_url) }}
                                 </div>
                             </div>
                             <div class="row">
-                                <div class="col-3"><span>{{ 'キャンセルURL'|trans }}</span><span
-                                        class="badge badge-primary ml-1">{{ 'smartpay.admin.config.required'|trans }}</span></div>
+                                <div class="col-3"><span>{{ 'キャンセルURL'|trans }}</span></div>
                                 <div class="col mb-2">
                                     {{ form_widget(form.cancel_url) }}
                                     {{ form_errors(form.cancel_url) }}


### PR DESCRIPTION
Ticket: https://app.shortcut.com/smartpay/story/7415/allow-empty-success-cancel-urls-to-be-saved

Slack ref: https://smartpay-co.slack.com/archives/C026Q3DEHNJ/p1662598770600809