### PR TITLE
[sc-10218] Fix smartpayPaymentCheckoutID is not saved

### DIFF
--- a/Controller/PaymentController.php
+++ b/Controller/PaymentController.php
@@ -247,9 +247,8 @@ class PaymentController extends AbstractShoppingController
             $checkoutSession = httpPost($url, $data);
             $sessionID = $checkoutSession['id'];
             $Order->setSmartpayPaymentCheckoutID($sessionID);
-
-            header("Location: {$checkoutSession['url']}");
-            exit;
+            $this->entityManager->flush();
+            return $this->redirect($checkoutSession['url']);
         } catch (\Exception $e) {
             $this->addError($e->getMessage());
             return $this->redirectToRoute('shopping_error');


### PR DESCRIPTION
The `smartpayPaymentCheckoutID` field is not properly saved, due to:
- Missing `entityManager->flush()`
- Does not finish the controller method properly

This PR resolves this issue.
![image](https://user-images.githubusercontent.com/88208/219842190-a6309025-b171-4f70-b2f3-ce95f7a39483.png)


